### PR TITLE
Add minimal Synesthesia simulation

### DIFF
--- a/synesthesia/__init__.py
+++ b/synesthesia/__init__.py
@@ -1,0 +1,11 @@
+"""Synesthesia package.
+
+This package provides a minimal simulation of the Synesthesia toolkit
+described in the README. It exposes simple sensor abstractions, mapping
+logic, and placeholder audio/visual outputs. The implementation is kept
+small so it can run in a limited execution environment.
+"""
+
+__all__ = ["sensors", "audio", "visuals", "mapping"]
+
+__version__ = "0.1.0"

--- a/synesthesia/audio.py
+++ b/synesthesia/audio.py
@@ -1,0 +1,38 @@
+"""Placeholder audio engine."""
+from __future__ import annotations
+
+import math
+import os
+import struct
+import wave
+from tempfile import NamedTemporaryFile
+
+
+DEFAULT_SAMPLE_RATE = 44100
+
+
+def _sine_wave(freq: float, duration: float, volume: float = 0.5) -> bytes:
+    """Generate a sine wave as bytes."""
+    samples = int(duration * DEFAULT_SAMPLE_RATE)
+    data = bytearray()
+    for i in range(samples):
+        val = volume * math.sin(2 * math.pi * freq * (i / DEFAULT_SAMPLE_RATE))
+        # 16 bit signed
+        data.extend(struct.pack("<h", int(val * 32767)))
+    return bytes(data)
+
+
+def play_tone(freq: float, duration: float = 0.5, volume: float = 0.5) -> None:
+    """Play a tone using the system's default player if available."""
+    wave_data = _sine_wave(freq, duration, volume)
+    with NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+        with wave.open(tmp, "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(DEFAULT_SAMPLE_RATE)
+            w.writeframes(wave_data)
+        tmp_path = tmp.name
+    # Attempt to play using 'aplay' or 'afplay'. Fallback is console beep.
+    if os.system(f"aplay -q {tmp_path}") != 0:
+        os.system(f"afplay {tmp_path} >/dev/null 2>&1")
+    os.unlink(tmp_path)

--- a/synesthesia/main.py
+++ b/synesthesia/main.py
@@ -1,0 +1,50 @@
+"""CLI to run a simple Synesthesia session."""
+from __future__ import annotations
+
+import argparse
+import time
+
+from . import audio, sensors, visuals
+from .mapping import Action, Mapping
+
+
+def build_default_mapping() -> Mapping:
+    sns = sensors.default_sensors()
+    mapping = Mapping(sns)
+    vis = visuals.Visualizer()
+    vis.start()
+
+    def audio_action(value: float) -> None:
+        freq = 440 + value * 100  # simple modulation
+        print(f"[audio] playing frequency {freq:.1f}Hz")
+        audio.play_tone(freq, duration=0.1)
+
+    def visual_action(value: float) -> None:
+        vis.render(value)
+
+    mapping.link("accelerometer", Action(audio_action))
+    mapping.link("gyroscope", Action(visual_action))
+    return mapping
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Synesthesia simulation")
+    parser.add_argument("--steps", type=int, default=20, help="number of steps to run")
+    args = parser.parse_args()
+
+    mapping = build_default_mapping()
+    try:
+        for _ in range(args.steps):
+            mapping.step()
+            time.sleep(0.2)
+    finally:
+        # ensure visualizer window closes
+        if isinstance(mapping._map.get("gyroscope"), Action):
+            mapping._map["gyroscope"].callback(0)  # draw final
+        if visuals.Canvas is not None:
+            mapping._map["gyroscope"].callback(0)
+            mapping._map["gyroscope"].callback.__self__.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/synesthesia/mapping.py
+++ b/synesthesia/mapping.py
@@ -1,0 +1,30 @@
+"""Mapping logic for sensors to actions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+from .sensors import Sensor
+
+
+@dataclass
+class Action:
+    """Represents an action triggered by a sensor."""
+
+    callback: Callable[[float], None]
+
+
+class Mapping:
+    """Container for sensor-action mappings."""
+
+    def __init__(self, sensors: Dict[str, Sensor]):
+        self.sensors = sensors
+        self._map: Dict[str, Action] = {}
+
+    def link(self, sensor_name: str, action: Action) -> None:
+        self._map[sensor_name] = action
+
+    def step(self) -> None:
+        for name, action in self._map.items():
+            value = self.sensors[name].read()
+            action.callback(value)

--- a/synesthesia/sensors.py
+++ b/synesthesia/sensors.py
@@ -1,0 +1,38 @@
+"""Sensor abstractions.
+
+This module defines simple sensor classes that generate data. In a real
+Android environment these would interface with device hardware. For this
+simulation we generate random values or allow manual setting of sensor
+values for testing.
+"""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+
+@dataclass
+class Sensor:
+    """Base class for a sensor."""
+
+    name: str
+    unit: str = ""
+    getter: Callable[[], float] | None = None
+
+    def read(self) -> float:
+        if self.getter:
+            return float(self.getter())
+        # Fallback to random value
+        return random.uniform(-1.0, 1.0)
+
+
+def default_sensors() -> Dict[str, Sensor]:
+    """Return a set of default sensors used by the app."""
+    return {
+        "accelerometer": Sensor("accelerometer", "g"),
+        "gyroscope": Sensor("gyroscope", "deg/s"),
+        "light": Sensor("light", "lx"),
+        "proximity": Sensor("proximity", "cm"),
+        "magnetometer": Sensor("magnetometer", "uT"),
+    }

--- a/synesthesia/visuals.py
+++ b/synesthesia/visuals.py
@@ -1,0 +1,48 @@
+"""Placeholder visuals module."""
+from __future__ import annotations
+
+
+try:
+    from tkinter import Canvas, Tk
+except Exception:  # pragma: no cover - fallback if Tk not available
+    Canvas = None
+    Tk = None
+
+
+class Visualizer:
+    """Simple visualizer using Tkinter."""
+
+    def __init__(self) -> None:
+        self.tk = None
+        self.canvas = None
+
+    def start(self) -> None:
+        if Tk is None:
+            print("[visuals] Tkinter not available; running headless")
+            return
+        self.tk = Tk()
+        self.tk.title("Synesthesia Visualizer")
+        self.canvas = Canvas(self.tk, width=400, height=400)
+        self.canvas.pack()
+
+    def render(self, value: float) -> None:
+        if self.canvas is None:
+            print(f"[visuals] intensity: {value:.2f}")
+            return
+        self.canvas.delete("all")
+        center = 200
+        radius = abs(value) * 100 + 10
+        self.canvas.create_oval(
+            center - radius,
+            center - radius,
+            center + radius,
+            center + radius,
+            fill="cyan",
+        )
+        self.tk.update()
+
+    def stop(self) -> None:
+        if self.tk is not None:
+            self.tk.destroy()
+            self.tk = None
+            self.canvas = None

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,16 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from synesthesia import sensors, mapping
+
+
+def test_mapping_step_runs():
+    sns = sensors.default_sensors()
+    m = mapping.Mapping(sns)
+    called = {}
+
+    def cb(val):
+        called['v'] = val
+
+    m.link('accelerometer', mapping.Action(cb))
+    m.step()
+    assert 'v' in called


### PR DESCRIPTION
## Summary
- add a small `synesthesia` package that simulates sensors, audio tones, and simple visuals
- provide basic mapping logic and CLI entry point
- include a simple pytest verifying mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4d3c2c7083259d4e5eb5e09ec35f